### PR TITLE
add piccolomultidocs trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    tags: ['*']
+    tags: ["*"]
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.
@@ -18,7 +18,7 @@ jobs:
       contents: write
       statuses: write
     env:
-      DOC_TEMPLATE_VERSION: "v0.2.0"  # Change this to the specific tag version you want
+      DOC_TEMPLATE_VERSION: "v0.2.0" # Change this to the specific tag version you want
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -42,3 +42,17 @@ jobs:
             using PiccoloQuantumObjects
             DocMeta.setdocmeta!(PiccoloQuantumObjects, :DocTestSetup, :(using PiccoloQuantumObjects); recursive=true)
             doctest(PiccoloQuantumObjects)'
+
+  dispatch:
+    name: Dispatch PiccoloMultiDocs
+    runs-on: ubuntu-latest
+    needs: docs
+    if: github.ref_type == 'tag' && github.ref_name != ''
+    steps:
+      - name: Dispatch PiccoloMultiDocs workflow
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: harmoniqs/PiccoloMultiDocs.jl
+          event-type: rebuild-docs
+          client-payload: '{"ref": "${{ github.ref }}"}'


### PR DESCRIPTION
only runs after docs build is successful, no need for separate workflow

requires tag to flow down