### PR TITLE
Bump version to 0.7.1 and update compatibility constraints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PiccoloQuantumObjects"
 uuid = "5a402ddf-f93c-42eb-975e-5582dcda653d"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 ExponentialAction = "e24c0720-ea99-47e8-929e-571b494574d3"
@@ -22,10 +22,10 @@ QuantumToolboxExt = ["QuantumToolbox"]
 
 [compat]
 ExponentialAction = "0.2"
-ForwardDiff = "0.10, 1.0"
+ForwardDiff = "1.2"
 LinearAlgebra = "1.10, 1.11, 1.12"
-NamedTrajectories = "0.5"
-ProgressMeter = "1.10"
+NamedTrajectories = "0.6"
+ProgressMeter = "1.11"
 Reexport = "1.2"
 SparseArrays = "1.10, 1.11, 1.12"
 TestItemRunner = "1.1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -9,10 +9,4 @@ PiccoloQuantumObjects = "5a402ddf-f93c-42eb-975e-5582dcda653d"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
-CairoMakie = "0.13"
-Documenter = "1.15"
-Literate = "2.20"
-LiveServer = "1.5"
-NamedTrajectories = "0.5"
-PiccoloDocsTemplate = "0.2"
-Revise = "3.11"
+

--- a/ext/QuantumToolboxExt.jl
+++ b/ext/QuantumToolboxExt.jl
@@ -87,7 +87,7 @@ get_c_ops(sys::OpenQuantumSystem) = Qobj.(sys.dissipation_operators)
         res = mesolve(H_t, ψ0, get_times(traj))
         
         @test abs2(res.states[end]'ψT) ≈ 1.0 atol=1e-2
-        @test length(res.states) == traj.T
+        @test length(res.states) == traj.N
     end
 
     @testset "mesolve with OpenQuantumSystem and traj" begin
@@ -96,11 +96,11 @@ get_c_ops(sys::OpenQuantumSystem) = Qobj.(sys.dissipation_operators)
 
         res = mesolve(H_t, ψ0, get_times(traj))
         @test size(res.states[end]) == (2,)
-        @test length(res.states) == traj.T
+        @test length(res.states) == traj.N
 
         open_res = mesolve(H_t, ψ0, get_times(traj), get_c_ops(open_sys))
         @test size(open_res.states[end]) == (2, 2)
-        @test length(open_res.states) == traj.T
+        @test length(open_res.states) == traj.N
 
         # @test abs2(res.states[end]'ψT) ≈ 1.0 atol=1e-2
     end


### PR DESCRIPTION
This pull request mainly updates test assertions in the `QuantumToolboxExt.jl` extension to use the correct trajectory length field and removes compatibility constraints from the documentation project file. The key changes are:

**Test corrections and improvements:**

* Updated tests in `ext/QuantumToolboxExt.jl` to compare the length of `res.states` and `open_res.states` against `traj.N` instead of `traj.T`, ensuring the tests check the correct field for trajectory length. [[1]](diffhunk://#diff-b22b9c65f7d7e152e85436079fedae1756c6cbe706c8720303927b29e0f6798fL90-R90) [[2]](diffhunk://#diff-b22b9c65f7d7e152e85436079fedae1756c6cbe706c8720303927b29e0f6798fL99-R103)

**Documentation maintenance:**

* Removed version constraints for several dependencies in the `[compat]` section of `docs/Project.toml`, likely to allow for greater flexibility or to defer version pinning.