### PR TITLE
tagbot + manual tag docs rebuild trigger

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -29,3 +29,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+      - name: Re-trigger docs build
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: tagbot-release-created

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
     tags: ["*"]
+  repository_dispatch:
+    types: [tagbot-release-created]
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.
@@ -43,11 +45,11 @@ jobs:
             DocMeta.setdocmeta!(PiccoloQuantumObjects, :DocTestSetup, :(using PiccoloQuantumObjects); recursive=true)
             doctest(PiccoloQuantumObjects)'
 
-  dispatch:
-    name: Dispatch PiccoloMultiDocs
+  tagbot-dispatch:
+    name: Dispatch on TagBot Release
     runs-on: ubuntu-latest
     needs: docs
-    if: github.ref_type == 'tag' && github.ref_name != ''
+    if: github.event_name == 'repository_dispatch'
     steps:
       - name: Dispatch PiccoloMultiDocs workflow
         uses: peter-evans/repository-dispatch@v2
@@ -55,4 +57,16 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: harmoniqs/PiccoloMultiDocs.jl
           event-type: rebuild-docs
-          client-payload: '{"ref": "${{ github.ref }}"}'
+
+  tag-push-dispatch:
+    name: Dispatch on Tag Push
+    runs-on: ubuntu-latest
+    needs: docs
+    if: github.ref_type == 'tag'
+    steps:
+      - name: Dispatch PiccoloMultiDocs workflow
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: harmoniqs/PiccoloMultiDocs.jl
+          event-type: rebuild-docs


### PR DESCRIPTION
in order to rebuild the docs with the latest created tags, we tagbot to retrigger the docs workflow after completion. In addition, we want the docs workflow to support manually pushing docs to rebuild to docs. This way, users updating documentation without bumping the version can still (force) push the vX.Y.Z+docs tag, updating the documentation for that version.