### PR TITLE
chore: bump named trajectories to v0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PiccoloQuantumObjects"
 uuid = "5a402ddf-f93c-42eb-975e-5582dcda653d"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 ExponentialAction = "e24c0720-ea99-47e8-929e-571b494574d3"
@@ -24,7 +24,7 @@ QuantumToolboxExt = ["QuantumToolbox"]
 ExponentialAction = "0.2"
 ForwardDiff = "1.2"
 LinearAlgebra = "1.10, 1.11, 1.12"
-NamedTrajectories = "0.7"
+NamedTrajectories = "0.8"
 ProgressMeter = "1.11"
 Reexport = "1.2"
 SparseArrays = "1.10, 1.11, 1.12"


### PR DESCRIPTION
NamedTrajectories.jl has been updated to v0.8. With this update comes updated compat with the latest version of Makie, and the associated plotting extension for NamedTrajectories.jl. To support the latest features of Makie upstream and avoid compat issues, we are bumping our version of NM.